### PR TITLE
Hide blog section from navigation

### DIFF
--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -9,7 +9,6 @@ const links = [
   { href: "/", label: "About" },
   { href: "/research/", label: "Research" },
   { href: "/cv/", label: "CV" },
-  { href: "/blog/", label: "Blog" },
 ];
 
 function isActive(href: string, current: string): boolean {


### PR DESCRIPTION
Remove the blog link from the navigation menu while keeping blog content accessible directly.