### PR TITLE
Add Elastic Training Harness project and rename navigation

### DIFF
--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -8,7 +8,7 @@ const { currentPath = "/" } = Astro.props;
 const links = [
   { href: "/", label: "About" },
   { href: "/research/", label: "Research" },
-  { href: "/projects/", label: "Projects" },
+  { href: "/projects/", label: "Side Projects" },
   { href: "/cv/", label: "CV" },
 ];
 

--- a/src/content/projects/elastic-training-harness.md
+++ b/src/content/projects/elastic-training-harness.md
@@ -1,0 +1,9 @@
+---
+title: "Elastic Training Harness"
+date: 2025-01-12
+description: "A fault-tolerant distributed training system for LLM development that automatically manages node failures and workload rebalancing, achieving sub-30 second recovery times."
+repoUrl: "https://github.com/mmcmanus1/elastic-training-harness"
+tags: ["Python", "PyTorch", "distributed systems", "LLM training", "fault tolerance"]
+---
+
+Distributed training framework enabling resilient LLM training across multiple nodes through automatic failure detection, dynamic re-sharding, and multi-tier checkpointing (in-memory, NVMe, S3). Features learning rate scaling that automatically adjusts when batch size changes due to cluster size variations.


### PR DESCRIPTION
Adds the Elastic Training Harness project to the side projects page, a fault-tolerant distributed training system for LLM development with automatic failure detection and sub-30 second recovery times.

Also renames the navigation link from "Projects" to "Side Projects" for consistency with the page heading.