### PR TITLE
Add MIT Pokerbots 2022 and 2023 projects

### DIFF
--- a/src/content/projects/pokerbots-2022.md
+++ b/src/content/projects/pokerbots-2022.md
@@ -1,0 +1,9 @@
+---
+title: "MIT Pokerbots 2022"
+date: 2022-01-01
+description: "Poker game engine and course materials for MIT's 6.176, a programming competition where students build algorithmic poker-playing bots during IAP."
+repoUrl: "https://github.com/mitpokerbots/engine-2022"
+tags: ["Python", "Java", "C++", "game engine", "poker"]
+---
+
+Developed the core game engine infrastructure for running poker bot competitions at MIT. The engine supports skeleton bots in Python, Java, and C++ to accommodate different developer preferences. Also created course materials teaching students poker strategy and bot development.

--- a/src/content/projects/pokerbots-2023.md
+++ b/src/content/projects/pokerbots-2023.md
@@ -1,0 +1,9 @@
+---
+title: "MIT Pokerbots 2023"
+date: 2023-01-01
+description: "Poker game engine and course materials for MIT's 6.176, a programming competition where students build algorithmic poker-playing bots during IAP."
+repoUrl: "https://github.com/mitpokerbots/engine-2023"
+tags: ["Python", "Java", "C++", "game engine", "poker"]
+---
+
+Continued development of the poker bot competition infrastructure for MIT's annual IAP programming competition. The engine runs matches between student-developed bots, handling game state, betting logic, and tournament management.


### PR DESCRIPTION
## Summary
Add two new project entries documenting development of the MIT Pokerbots competition infrastructure for the 6.176 course during IAP. These projects showcase the evolution of the game engine from 2022 through 2023.

## Details
- pokerbots-2022.md: Initial development of the core game engine infrastructure supporting Python, Java, and C++ skeleton bots
- pokerbots-2023.md: Continued development adding tournament management and match execution features