### PR TITLE
Add MIT Pokerbots 2021 project

### DIFF
--- a/src/content/projects/pokerbots-2021.md
+++ b/src/content/projects/pokerbots-2021.md
@@ -1,0 +1,9 @@
+---
+title: "MIT Pokerbots 2021"
+date: 2021-01-01
+description: "Poker game engine and course materials for MIT's 6.176, a programming competition where students build algorithmic poker-playing bots during IAP."
+repoUrl: "https://github.com/mitpokerbots/engine-2021"
+tags: ["Python", "Java", "C++", "game engine", "poker"]
+---
+
+Developed the core game engine infrastructure for running poker bot competitions at MIT. The engine supports skeleton bots in Python, Java, and C++ to accommodate different developer preferences. Also created course materials teaching students poker strategy and bot development.


### PR DESCRIPTION
Adds MIT Pokerbots 2021 to the projects section, matching the existing 2022 and 2023 entries. The project file is automatically discovered by Astro's content collection and will appear on the projects page sorted by date.