### PR TITLE
Add RLHF Canary and other projects

### DIFF
--- a/src/content/projects/rlhf-canary.md
+++ b/src/content/projects/rlhf-canary.md
@@ -1,0 +1,9 @@
+---
+title: "RLHF Canary"
+date: 2025-01-01
+description: "A regression detection system for RLHF and finetuning pipelines. Automatically catches performance, stability, and correctness regressions by monitoring training metrics and comparing against baselines."
+repoUrl: "https://github.com/mmcmanus1/rlhf-canary"
+tags: ["Python", "PyTorch", "RLHF", "ML Ops", "Hugging Face"]
+---
+
+Regression detection tool for ML training pipelines that monitors tokens/second, memory usage, and numerical stability. Features automated root cause analysis, GitHub Actions integration, and YAML-based configuration with smoke, performance, and nightly test tiers.


### PR DESCRIPTION
Adds RLHF Canary regression detection project to the portfolio, along with other side projects. Updates profile tagline to Quantitative Researcher reflecting DRW experience, updates Google Scholar link, and adds navigation link to Side Projects page.