### PR TITLE
Update profile tagline to MIT CS & Math

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -11,7 +11,7 @@
     height="120"
   />
   <h1 class="profile-name">Matt McManus</h1>
-  <p class="profile-tagline">Quantitative Researcher</p>
+  <p class="profile-tagline">Quantitative Researcher • MIT CS & Math</p>
 
   <div class="social-icons">
     <!-- Email -->


### PR DESCRIPTION
## Summary
- Updates the tagline under the profile name from "Quantitative Researcher" to "MIT CS & Math • Quantitative Researcher"

## Test plan
- [ ] Verify the tagline displays correctly on the site