### PR TITLE
Remove 'Quantitative Researcher' from profile tagline

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -11,7 +11,7 @@
     height="120"
   />
   <h1 class="profile-name">Matt McManus</h1>
-  <p class="profile-tagline">Quantitative Researcher • MIT CS & Math</p>
+  <p class="profile-tagline">MIT CS & Math</p>
 
   <div class="social-icons">
     <!-- Email -->


### PR DESCRIPTION
Simplifies the profile tagline to show only "MIT CS & Math" instead of "Quantitative Researcher • MIT CS & Math".