### PR TITLE
Add visual separators to paper and project cards

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -210,6 +210,13 @@ main {
 /* Paper Cards */
 .paper {
   margin-bottom: var(--spacing-lg);
+  padding-bottom: var(--spacing-lg);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.paper:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
 }
 
 .paper-title {
@@ -240,6 +247,13 @@ main {
 /* Project Cards */
 .project {
   margin-bottom: var(--spacing-lg);
+  padding-bottom: var(--spacing-lg);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.project:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
 }
 
 .project-title {


### PR DESCRIPTION
## Summary
Adds bottom borders and padding to paper and project card elements to provide visual separation. The last item in each group has no border to maintain clean spacing.

## Changes
- Added `padding-bottom` and `border-bottom` to `.paper` and `.project` classes
- Added `:last-child` selectors to remove borders from the last item in each group