### PR TITLE
Add DRW prediction markets experience to homepage

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,7 +4,7 @@ import PageLayout from '../layouts/PageLayout.astro';
 
 <PageLayout>
   <p>
-    Research-oriented ML engineer focused on structure-aware learning and reliable decision systems.
+    Building <a href="https://drw.com/">DRW</a>'s prediction markets desk from the ground up — leading everything from business strategy and infrastructure to team formation and AI/ML-driven prediction development across Sports, Financial, Economic, Crypto, and Political markets.
   </p>
   <p>
     I focus on leakage-safe evaluation, probability calibration, and mechanistic probes for LLM agents in macro settings.
@@ -13,6 +13,9 @@ import PageLayout from '../layouts/PageLayout.astro';
   <hr />
 
   <ul>
+    <li>
+      Building <a href="https://drw.com/">DRW</a>'s prediction markets desk from scratch — owning the business plan, infrastructure, and team buildout. Developing AI/ML-driven prediction capabilities and automated market-making strategies, collaborating with engineering and quant research teams across a multi-asset trading organization.
+    </li>
     <li>
       Previously an ML Engineer at <a href="https://www.bridgewater.com/">Bridgewater Associates</a> (AIA Labs), building calibrated LLM forecasting systems with time-keyed evaluation and LLM-as-Judge probes.
     </li>


### PR DESCRIPTION
## Summary

- Updates the homepage intro paragraph to highlight current role building DRW's prediction markets desk
- Adds a new experience bullet for DRW covering business strategy, infrastructure, team buildout, and AI/ML-driven prediction capabilities