### PR TITLE
Simplify homepage copy for clarity and conciseness

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,17 +4,14 @@ import PageLayout from '../layouts/PageLayout.astro';
 
 <PageLayout>
   <p>
-    Building <a href="https://drw.com/">DRW</a>'s prediction markets desk from the ground up — leading everything from business strategy and infrastructure to team formation and AI/ML-driven prediction development across Sports, Financial, Economic, Crypto, and Political markets.
-  </p>
-  <p>
-    I focus on leakage-safe evaluation, probability calibration, and mechanistic probes for LLM agents in macro settings.
+    Currently building <a href="https://drw.com/">DRW</a>'s prediction markets desk from the ground up.
   </p>
 
   <hr />
 
   <ul>
     <li>
-      Building <a href="https://drw.com/">DRW</a>'s prediction markets desk from scratch — owning the business plan, infrastructure, and team buildout. Developing AI/ML-driven prediction capabilities and automated market-making strategies, collaborating with engineering and quant research teams across a multi-asset trading organization.
+      At <a href="https://drw.com/">DRW</a>, leading the buildout of a prediction markets business from business strategy and infrastructure to hiring and automated market-making.
     </li>
     <li>
       Previously an ML Engineer at <a href="https://www.bridgewater.com/">Bridgewater Associates</a> (AIA Labs), building calibrated LLM forecasting systems with time-keyed evaluation and LLM-as-Judge probes.
@@ -23,10 +20,10 @@ import PageLayout from '../layouts/PageLayout.astro';
       Previously a Quantitative Researcher at <a href="https://www.twosigma.com/">Two Sigma</a>, developing factor-neutral cross-sectional alphas and leakage-safe walk-forward pipelines.
     </li>
     <li>
-      M.Eng. in Computer Science and B.S. in Mathematics & Computer Science from <a href="https://www.eecs.mit.edu/">MIT</a> (GPA: 5.0/5.0). Worked with <a href="https://math.mit.edu/~edelman/">Alan Edelman</a> at the Julia Lab on physics-informed neural ODEs, and <a href="https://alfagroup.csail.mit.edu/unamay">Una-May O'Reilly</a> at the ALFA Lab on neuro-symbolic cybersecurity.
+      M.Eng. in Computer Science and B.S. in Mathematics & Computer Science from <a href="https://www.eecs.mit.edu/">MIT</a> (GPA: 5.0/5.0). Worked with <a href="https://math.mit.edu/~edelman/">Alan Edelman</a> at the Julia Lab on physics-informed neural ODEs and <a href="https://alfagroup.csail.mit.edu/unamay">Una-May O'Reilly</a> at the ALFA Lab on neuro-symbolic cybersecurity.
     </li>
     <li>
-      President of <a href="https://pokerbots.org">MIT Pokerbots</a>, a month-long autonomous poker competition for 250+ students. This sparked my interest in game theory and reinforcement learning.
+      President of <a href="https://pokerbots.org">MIT Pokerbots</a>, a month-long autonomous poker competition for 250+ students — where my interest in game theory and reinforcement learning took root.
     </li>
   </ul>
 


### PR DESCRIPTION
## Summary

- Condensed the intro from two paragraphs to a single concise sentence
- Tightened DRW experience bullet point and reworded for clarity
- Refined MIT education and Pokerbots bullet points with minor punctuation and phrasing improvements