### PR TITLE
Add Twitter/X social link to header

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -35,6 +35,13 @@
       </svg>
     </a>
 
+    <!-- X (Twitter) -->
+    <a href="https://x.com/mattmcmanus41" title="X (Twitter)" aria-label="X (Twitter)" target="_blank" rel="noopener">
+      <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <path d="M18.901 1.153h3.68l-8.04 9.19L24 22.846h-7.406l-5.8-7.584-6.638 7.584H.474l8.6-9.83L0 1.154h7.594l5.243 6.932ZM17.61 20.644h2.039L6.486 3.24H4.298Z"/>
+      </svg>
+    </a>
+
     <!-- Google Scholar -->
     <a href="https://scholar.google.com/citations?user=v_LhktsAAAAJ&hl=en" title="Google Scholar" aria-label="Google Scholar" target="_blank" rel="noopener">
       <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
## Summary
- Adds an X (Twitter) icon and link to the header social icons section
- Links to https://x.com/mattmcmanus41
- Placed between LinkedIn and Google Scholar, following the same pattern as existing social links