### PR TITLE
Update homepage headline to Quant Researcher at DRW

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,7 +4,7 @@ import PageLayout from '../layouts/PageLayout.astro';
 
 <PageLayout>
   <p>
-    Currently building <a href="https://drw.com/">DRW</a>'s prediction markets desk from the ground up.
+    Quant Researcher at <a href="https://drw.com/">DRW</a>.
   </p>
 
   <hr />


### PR DESCRIPTION
Updates the homepage headline to plainly state the role: "Quant Researcher at DRW" (with the DRW link preserved), replacing the previous "Currently building DRW's prediction markets desk from the ground up" copy.