### PR TITLE
Reword DRW prediction markets bullet

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,7 +11,7 @@ import PageLayout from '../layouts/PageLayout.astro';
 
   <ul>
     <li>
-      At <a href="https://drw.com/">DRW</a>, leading the buildout of a prediction markets business from business strategy and infrastructure to hiring and automated market-making.
+      Working on prediction markets at <a href="https://drw.com/">DRW</a> — strategy, infrastructure, hiring, and automated market-making.
     </li>
     <li>
       Previously an ML Engineer at <a href="https://www.bridgewater.com/">Bridgewater Associates</a> (AIA Labs), building calibrated LLM forecasting systems with time-keyed evaluation and LLM-as-Judge probes.


### PR DESCRIPTION
Simplifies the first homepage bullet describing the DRW role. Drops the "leading the buildout" framing in favor of neutral phrasing, and trims the wordy "from … to …" construction into a short specifics list. The DRW link is preserved.